### PR TITLE
Add IEC61850 frame analyzer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
-# Makefile — installer ptp-diag
+# Makefile — installer ptp-diag and IEC61850 analyzer
 .RECIPEPREFIX := >
 SHELL := /bin/bash
 
 PREFIX ?= /usr/local
+
 APP_DIR ?= /opt/ptp-diag
 BIN_NAME ?= ptp-diag
 SCRIPT_SRC ?= ptp_diag.py
 WRAPPER := $(PREFIX)/bin/$(BIN_NAME)
+
+APP_DIR_IEC ?= /opt/iec61850-diag
+BIN_NAME_IEC ?= iec61850-diag
+SCRIPT_SRC_IEC ?= iec61850_diag.py
+WRAPPER_IEC := $(PREFIX)/bin/$(BIN_NAME_IEC)
 
 .PHONY: all deps install uninstall check clean
 
@@ -18,32 +24,53 @@ deps:
 > sudo apt-get install -y -qq linuxptp python3-venv
 
 install: deps
-> test -f "$(SCRIPT_SRC)" || { echo "Missing $(SCRIPT_SRC)"; exit 1; }
+> for f in $(SCRIPT_SRC) $(SCRIPT_SRC_IEC); do \
+>   test -f "$$f" || { echo "Missing $$f"; exit 1; }; \
+> done
 > echo "[install] Creating app dir: $(APP_DIR)"
 > sudo mkdir -p "$(APP_DIR)"
-> echo "[install] Copying script"
+> echo "[install] Copying ptp script"
 > sudo install -m 0755 "$(SCRIPT_SRC)" "$(APP_DIR)/ptp_diag.py"
-> echo "[install] Creating virtualenv"
+> echo "[install] Creating virtualenv for ptp"
 > sudo python3 -m venv "$(APP_DIR)/venv"
+> echo "[install] Installing Python deps"
+> sudo "$(APP_DIR)/venv/bin/pip" install -r requirements.txt
 > echo "[install] Generating wrapper: $(WRAPPER)"
 > printf '%s\n' '#!/usr/bin/env bash' \
 >   'APP_DIR="$(APP_DIR)"' \
->   'exec "$${APP_DIR}/venv/bin/python" "$${APP_DIR}/ptp_diag.py" "$$@"' \
+>   'exec "$$APP_DIR/venv/bin/python" "$$APP_DIR/ptp_diag.py" "$$@"' \
 >   | sudo tee "$(WRAPPER)" >/dev/null
 > sudo chmod 0755 "$(WRAPPER)"
-> echo "[ok] Installed. Usage: sudo $(BIN_NAME) -i eth0"
+> echo "[install] Creating app dir: $(APP_DIR_IEC)"
+> sudo mkdir -p "$(APP_DIR_IEC)"
+> echo "[install] Copying IEC61850 script"
+> sudo install -m 0755 "$(SCRIPT_SRC_IEC)" "$(APP_DIR_IEC)/iec61850_diag.py"
+> echo "[install] Creating virtualenv for IEC61850"
+> sudo python3 -m venv "$(APP_DIR_IEC)/venv"
+> echo "[install] Installing Python deps"
+> sudo "$(APP_DIR_IEC)/venv/bin/pip" install -r requirements.txt
+> echo "[install] Generating wrapper: $(WRAPPER_IEC)"
+> printf '%s\n' '#!/usr/bin/env bash' \
+>   'APP_DIR="$(APP_DIR_IEC)"' \
+>   'exec "$$APP_DIR/venv/bin/python" "$$APP_DIR/iec61850_diag.py" "$$@"' \
+>   | sudo tee "$(WRAPPER_IEC)" >/dev/null
+> sudo chmod 0755 "$(WRAPPER_IEC)"
+> echo "[ok] Installed. Usage: sudo $(BIN_NAME) -i eth0 | sudo $(BIN_NAME_IEC) -i eth0"
 
 uninstall:
 > echo "[uninstall] Removing wrapper: $(WRAPPER)"
 > sudo rm -f "$(WRAPPER)"
 > echo "[uninstall] Removing app dir: $(APP_DIR)"
 > sudo rm -rf "$(APP_DIR)"
+> echo "[uninstall] Removing wrapper: $(WRAPPER_IEC)"
+> sudo rm -f "$(WRAPPER_IEC)"
+> echo "[uninstall] Removing app dir: $(APP_DIR_IEC)"
+> sudo rm -rf "$(APP_DIR_IEC)"
 > echo "[ok] Uninstalled."
 
 check:
-> python3 -m py_compile $(SCRIPT_SRC)
+> python3 -m py_compile $(SCRIPT_SRC) $(SCRIPT_SRC_IEC)
 > echo "[ok] Python syntax checks passed."
 
 clean:
 > echo "Nothing to clean."
-

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # networkanalyser
+
+Outils d'analyse réseau pour PTP et IEC 61850.
+
+## Scripts
+
+- `ptp_diag.py` : analyse des trames PTP via linuxptp.
+- `iec61850_diag.py` : détection des trames IEC61850 (GOOSE, SV) et rapports MMS.
+
+## Installation
+
+```sh
+sudo make install
+```
+
+## Utilisation
+
+```sh
+sudo ptp-diag -i eth0
+sudo iec61850-diag -i eth0
+```

--- a/iec61850_diag.py
+++ b/iec61850_diag.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+iec61850_diag.py — IEC 61850 frame analyzer.
+
+Detects GOOSE and Sampled Values (SV) frames and counts them per
+source address in 10-second windows. Also prints a message when an
+MMS report is observed (TCP port 102 containing the word 'report').
+
+Usage:
+  sudo ./iec61850_diag.py -i eth0
+"""
+
+import argparse
+import collections
+import os
+import sys
+
+from scapy.all import Ether, Raw, TCP, sniff
+
+GOOSE_ETHER_TYPE = 0x88B8
+SV_ETHER_TYPE = 0x88BA
+MMS_TCP_PORT = 102
+
+
+def require_root():
+    if os.geteuid() != 0:
+        print("ERROR: run as root (sudo).", file=sys.stderr)
+        sys.exit(1)
+
+
+def analyze(iface):
+    goose_counts = collections.Counter()
+    sv_counts = collections.Counter()
+
+    def handle(pkt):
+        if Ether not in pkt:
+            return
+        src = pkt[Ether].src
+        etype = pkt[Ether].type
+        if etype == GOOSE_ETHER_TYPE:
+            goose_counts[src] += 1
+        elif etype == SV_ETHER_TYPE:
+            sv_counts[src] += 1
+        elif pkt.haslayer(TCP) and (
+            pkt[TCP].sport == MMS_TCP_PORT or pkt[TCP].dport == MMS_TCP_PORT
+        ):
+            if pkt.haslayer(Raw) and b"report" in pkt[Raw].load.lower():
+                print(f"MMS report from {src}")
+
+    try:
+        while True:
+            sniff(iface=iface, prn=handle, store=False, timeout=10)
+            if goose_counts or sv_counts:
+                print("=== 10s summary ===")
+                if goose_counts:
+                    print("GOOSE frames:")
+                    for addr, cnt in goose_counts.items():
+                        print(f"  {addr}: {cnt}")
+                if sv_counts:
+                    print("SV frames:")
+                    for addr, cnt in sv_counts.items():
+                        print(f"  {addr}: {cnt}")
+                goose_counts.clear()
+                sv_counts.clear()
+    except KeyboardInterrupt:
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="IEC 61850 frame analyzer")
+    parser.add_argument("-i", "--iface", required=True, help="Network interface (e.g., eth0)")
+    args = parser.parse_args()
+    require_root()
+    analyze(args.iface)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Pas de dépendances pip
+scapy>=2.5.0
+
 # Dépendances système :
 #   sudo apt-get install linuxptp python3-venv
-

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,10 @@ APP_DIR="/opt/ptp-diag"
 WRAPPER="/usr/local/bin/ptp-diag"
 SCRIPT_SRC="ptp_diag.py"
 
+APP_DIR_IEC="/opt/iec61850-diag"
+WRAPPER_IEC="/usr/local/bin/iec61850-diag"
+SCRIPT_SRC_IEC="iec61850_diag.py"
+
 if [[ $EUID -ne 0 ]]; then
   echo "Please run as root: sudo ./setup.sh"
   exit 1
@@ -13,31 +17,39 @@ fi
 
 command -v apt-get >/dev/null 2>&1 || { echo "apt-get not found."; exit 1; }
 
-echo "[1/5] Installing linuxptp and python3-venv…"
+echo "[1/8] Installing linuxptp and python3-venv…"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -y -qq linuxptp python3-venv
 
-echo "[2/5] Checking script source…"
-[[ -f "$SCRIPT_SRC" ]] || { echo "Missing $SCRIPT_SRC in current directory."; exit 1; }
+echo "[2/8] Checking script sources…"
+[[ -f "$SCRIPT_SRC" && -f "$SCRIPT_SRC_IEC" ]] || { echo "Missing scripts."; exit 1; }
 
-echo "[3/5] Creating app directory: $APP_DIR"
+echo "[3/8] Installing ptp-diag…"
 mkdir -p "$APP_DIR"
 install -m 0755 "$SCRIPT_SRC" "$APP_DIR/ptp_diag.py"
-
-echo "[4/5] Creating virtualenv…"
 python3 -m venv "$APP_DIR/venv"
-
-echo "[5/5] Creating wrapper: $WRAPPER"
-cat > "$WRAPPER" <<'EOF'
+"$APP_DIR/venv/bin/pip" install -r requirements.txt
+cat > "$WRAPPER" <<'EOW'
 #!/usr/bin/env bash
 APP_DIR="/opt/ptp-diag"
 exec "${APP_DIR}/venv/bin/python" "${APP_DIR}/ptp_diag.py" "$@"
-EOF
+EOW
 chmod 0755 "$WRAPPER"
 
-echo "[OK] Installation complete."
+echo "[4/8] Installing IEC61850 analyzer…"
+mkdir -p "$APP_DIR_IEC"
+install -m 0755 "$SCRIPT_SRC_IEC" "$APP_DIR_IEC/iec61850_diag.py"
+python3 -m venv "$APP_DIR_IEC/venv"
+"$APP_DIR_IEC/venv/bin/pip" install -r requirements.txt
+cat > "$WRAPPER_IEC" <<'EOW'
+#!/usr/bin/env bash
+APP_DIR="/opt/iec61850-diag"
+exec "${APP_DIR}/venv/bin/python" "${APP_DIR}/iec61850_diag.py" "$@"
+EOW
+chmod 0755 "$WRAPPER_IEC"
+
+echo "[5/8] Installation complete."
 echo "Usage:"
 echo "  sudo ptp-diag -i eth0"
-echo "  sudo ptp-diag -i eth0 --json"
-
+echo "  sudo iec61850-diag -i eth0"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,8 +5,11 @@ set -euo pipefail
 
 WRAPPER="/usr/local/bin/ptp-diag"
 APP_DIR="/opt/ptp-diag"
+WRAPPER_IEC="/usr/local/bin/iec61850-diag"
+APP_DIR_IEC="/opt/iec61850-diag"
 
 rm -f "$WRAPPER"
 rm -rf "$APP_DIR"
+rm -f "$WRAPPER_IEC"
+rm -rf "$APP_DIR_IEC"
 echo "[OK] Uninstalled."
-


### PR DESCRIPTION
## Summary
- add `iec61850_diag.py` to sniff IEC61850 traffic, count GOOSE and Sampled Value frames per source every 10s, and log MMS reports
- install new analyzer via Makefile/setup scripts and pip dependencies
- document usage and add scapy requirement

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68b55f89938883268e1a6923abd16d0f