### PR TITLE
Clarify dependency instructions for cli_chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ sudo iec61850-diag -i eth0
 
 ```sh
 pip install -r requirements.txt
-pip install openai
 ```
+
+Seules les bibliothèques listées dans `requirements.txt` sont nécessaires au
+fonctionnement de `cli_chat.py` ; le paquet `openai` n'est pas requis.
 
 ### Configuration de l'environnement
 


### PR DESCRIPTION
## Summary
- Clarify that only requirements.txt dependencies are required for cli_chat.py
- Remove unnecessary openai installation step in README

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68b5674a82d08326aea7111776f558ec