### PR TITLE
Add diagnostic and chat targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BIN_NAME_IEC ?= iec61850-diag
 SCRIPT_SRC_IEC ?= iec61850_diag.py
 WRAPPER_IEC := $(PREFIX)/bin/$(BIN_NAME_IEC)
 
-.PHONY: all deps install uninstall check clean
+.PHONY: all deps install uninstall check clean run-diagnostic logs chat check-key
 
 all: install
 
@@ -74,3 +74,16 @@ check:
 
 clean:
 > echo "Nothing to clean."
+
+# IFACE et DURATION sont optionnelles
+run-diagnostic:
+> python cli_chat.py run-diagnostic IFACE=$(IFACE) DURATION=$(DURATION)
+
+logs:
+> python cli_chat.py logs
+
+chat:
+> python cli_chat.py chat
+
+check-key:
+> python cli_chat.py check-key


### PR DESCRIPTION
## Summary
- add run-diagnostic target with optional IFACE and DURATION parameters
- add logs, chat, and check-key targets for `cli_chat.py`

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68b567e4066c832693de44c0c2523d89