### PR TITLE
Install chat and logs utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,14 @@
 SHELL := /bin/bash
 
 PREFIX ?= /usr/local
+PYTHON ?= python3
 
 APP_DIR ?= /opt/ptp-diag
 BIN_NAME ?= ptp-diag
 SCRIPT_SRC ?= ptp_diag.py
 WRAPPER := $(PREFIX)/bin/$(BIN_NAME)
+LOGS_WRAPPER := $(PREFIX)/bin/ptp-logs
+CHAT_WRAPPER := $(PREFIX)/bin/ptp-chat
 
 APP_DIR_IEC ?= /opt/iec61850-diag
 BIN_NAME_IEC ?= iec61850-diag
@@ -24,15 +27,17 @@ deps:
 > sudo apt-get install -y -qq linuxptp python3-venv
 
 install: deps
-> for f in $(SCRIPT_SRC) $(SCRIPT_SRC_IEC); do \
+> for f in $(SCRIPT_SRC) $(SCRIPT_SRC_IEC) cli_chat.py; do \
 >   test -f "$$f" || { echo "Missing $$f"; exit 1; }; \
 > done
 > echo "[install] Creating app dir: $(APP_DIR)"
 > sudo mkdir -p "$(APP_DIR)"
 > echo "[install] Copying ptp script"
 > sudo install -m 0755 "$(SCRIPT_SRC)" "$(APP_DIR)/ptp_diag.py"
+> echo "[install] Copying chat helper"
+> sudo install -m 0755 cli_chat.py "$(APP_DIR)/cli_chat.py"
 > echo "[install] Creating virtualenv for ptp"
-> sudo python3 -m venv "$(APP_DIR)/venv"
+> sudo $(PYTHON) -m venv "$(APP_DIR)/venv"
 > echo "[install] Installing Python deps"
 > sudo "$(APP_DIR)/venv/bin/pip" install -r requirements.txt
 > echo "[install] Generating wrapper: $(WRAPPER)"
@@ -41,12 +46,24 @@ install: deps
 >   'exec "$$APP_DIR/venv/bin/python" "$$APP_DIR/ptp_diag.py" "$$@"' \
 >   | sudo tee "$(WRAPPER)" >/dev/null
 > sudo chmod 0755 "$(WRAPPER)"
+> echo "[install] Generating wrapper: $(LOGS_WRAPPER)"
+> printf '%s\n' '#!/usr/bin/env bash' \
+>   'APP_DIR="$(APP_DIR)"' \
+>   'exec "$$APP_DIR/venv/bin/python" "$$APP_DIR/cli_chat.py" logs "$$@"' \
+>   | sudo tee "$(LOGS_WRAPPER)" >/dev/null
+> sudo chmod 0755 "$(LOGS_WRAPPER)"
+> echo "[install] Generating wrapper: $(CHAT_WRAPPER)"
+> printf '%s\n' '#!/usr/bin/env bash' \
+>   'APP_DIR="$(APP_DIR)"' \
+>   'exec "$$APP_DIR/venv/bin/python" "$$APP_DIR/cli_chat.py" chat "$$@"' \
+>   | sudo tee "$(CHAT_WRAPPER)" >/dev/null
+> sudo chmod 0755 "$(CHAT_WRAPPER)"
 > echo "[install] Creating app dir: $(APP_DIR_IEC)"
 > sudo mkdir -p "$(APP_DIR_IEC)"
 > echo "[install] Copying IEC61850 script"
 > sudo install -m 0755 "$(SCRIPT_SRC_IEC)" "$(APP_DIR_IEC)/iec61850_diag.py"
 > echo "[install] Creating virtualenv for IEC61850"
-> sudo python3 -m venv "$(APP_DIR_IEC)/venv"
+> sudo $(PYTHON) -m venv "$(APP_DIR_IEC)/venv"
 > echo "[install] Installing Python deps"
 > sudo "$(APP_DIR_IEC)/venv/bin/pip" install -r requirements.txt
 > echo "[install] Generating wrapper: $(WRAPPER_IEC)"
@@ -60,6 +77,10 @@ install: deps
 uninstall:
 > echo "[uninstall] Removing wrapper: $(WRAPPER)"
 > sudo rm -f "$(WRAPPER)"
+> echo "[uninstall] Removing wrapper: $(LOGS_WRAPPER)"
+> sudo rm -f "$(LOGS_WRAPPER)"
+> echo "[uninstall] Removing wrapper: $(CHAT_WRAPPER)"
+> sudo rm -f "$(CHAT_WRAPPER)"
 > echo "[uninstall] Removing app dir: $(APP_DIR)"
 > sudo rm -rf "$(APP_DIR)"
 > echo "[uninstall] Removing wrapper: $(WRAPPER_IEC)"
@@ -69,7 +90,7 @@ uninstall:
 > echo "[ok] Uninstalled."
 
 check:
-> python3 -m py_compile $(SCRIPT_SRC) $(SCRIPT_SRC_IEC)
+> $(PYTHON) -m py_compile $(SCRIPT_SRC) $(SCRIPT_SRC_IEC) cli_chat.py
 > echo "[ok] Python syntax checks passed."
 
 clean:
@@ -77,13 +98,13 @@ clean:
 
 # IFACE et DURATION sont optionnelles
 run-diagnostic:
-> python cli_chat.py run-diagnostic IFACE=$(IFACE) DURATION=$(DURATION)
+> $(PYTHON) cli_chat.py run-diagnostic IFACE=$(IFACE) DURATION=$(DURATION)
 
 logs:
-> python cli_chat.py logs
+> $(PYTHON) cli_chat.py logs
 
 chat:
-> python cli_chat.py chat
+> $(PYTHON) cli_chat.py chat
 
 check-key:
-> python cli_chat.py check-key
+> $(PYTHON) cli_chat.py check-key

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Outils d'analyse réseau pour PTP et IEC 61850.
 sudo make install
 ```
 
+Cette commande installe `ptp-diag`, `iec61850-diag` ainsi que les utilitaires
+`ptp-logs` et `ptp-chat` qui utilisent le même environnement virtuel.
+
 ## Configuration
 
 Copiez le fichier `.env.example` vers `.env` puis définissez la clé API `OPENROUTER_API_KEY` :
@@ -34,6 +37,8 @@ Le fichier `.env` est utilisé par `cli_chat.py` et n'est pas commité dans le d
 ```sh
 sudo ptp-diag -i eth0
 sudo iec61850-diag -i eth0
+ptp-logs
+ptp-chat
 ```
 
 ## Intégration IA
@@ -66,21 +71,21 @@ La clé ne doit jamais être committée dans le dépôt : le fichier `.env` est
 ### Exemples d'utilisation
 
 ```sh
-python cli_chat.py run-diagnostic -i eth0
-python cli_chat.py logs
-python cli_chat.py chat
+ptp-diag -i eth0
+ptp-logs
+ptp-chat
 ```
 
 #### Exemple complet
 
 ```sh
 # 1. Lancer un diagnostic PTP et générer les logs
-python cli_chat.py run-diagnostic -i eth0 -t 30
+ptp-diag -i eth0 -t 30
 
 # 2. Afficher les logs
-python cli_chat.py logs
+ptp-logs
 
 # 3. Ouvrir une conversation avec le modèle
-python cli_chat.py chat
+ptp-chat
 > Quels paquets GOOSE sont suspects ?
 ```


### PR DESCRIPTION
## Summary
- Install cli_chat.py alongside ptp-diag and generate wrappers for ptp-logs and ptp-chat
- Use python3 by default and expose new wrappers via Makefile targets
- Document new commands in README

## Testing
- `make check`
- `make logs`
- `make chat` *(fails: OPENROUTER_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b56d2665188326999361930e1b16f5