### PR TITLE
Load .env automatically for chat CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ OPENROUTER_API_KEY=votre_cle
 ```
 
 Le fichier `.env` est utilisé par `cli_chat.py` et n'est pas commité dans le dépôt.
+Il est automatiquement chargé s'il est présent dans le même dossier que le script
+(par exemple `/opt/ptp-diag/.env`).
 
 ## Utilisation
 
@@ -60,13 +62,8 @@ fonctionnement de `cli_chat.py` ; le paquet `openai` n'est pas requis.
    echo "OPENROUTER_API_KEY=\"votre_clé\"" > .env
    ```
 
-2. Charger les variables dans votre session :
-
-   ```sh
-   export $(grep -v '^#' .env | xargs)
-   ```
-
-La clé ne doit jamais être committée dans le dépôt : le fichier `.env` est ignoré par Git.
+2. La clé ne doit jamais être committée dans le dépôt : le fichier `.env` est ignoré
+   par Git et chargé automatiquement par `ptp-chat`.
 
 ### Exemples d'utilisation
 

--- a/cli_chat.py
+++ b/cli_chat.py
@@ -15,6 +15,7 @@ import logging
 import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import Optional
 
 from dotenv import load_dotenv
@@ -22,7 +23,9 @@ import requests
 
 # ---------- Environment / constants ----------
 
-load_dotenv()
+_ENV_FILE = Path(__file__).resolve().parent / ".env"
+if not load_dotenv(_ENV_FILE):
+    load_dotenv()
 
 LOG_FILE = "diagnostic.log"
 API_URL = "https://openrouter.ai/api/v1/chat/completions"


### PR DESCRIPTION
## Summary
- Ensure ptp-chat loads environment variables from a local .env file
- Document auto-loading of .env and simplify environment setup instructions

## Testing
- `make check`
- `python cli_chat.py check-key`

------
https://chatgpt.com/codex/tasks/task_e_68b5716afcd88326beef95cfb944063c